### PR TITLE
Immediate deletion of otl.key on demand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ include = ["sdh.otl"]
 [project]
 name = "sdh.otl"
 description = "Django one time link generator and processor"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
   "Django>=3.2"
 ]


### PR DESCRIPTION
I needed to dispose OTL key after it was used once for the purpose.